### PR TITLE
fixed some missing stuff.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -4,6 +4,7 @@ description: Bring MMORPG style classes to MC!
 author: Phenom
 authors: [Evan]
 main: com.phenom.argonauts.Main
+depend: [Denizen]
 commands:
   uuid:
     description: display your uuid.

--- a/src/com/phenom/argonauts/denizens/dAdventurer.java
+++ b/src/com/phenom/argonauts/denizens/dAdventurer.java
@@ -33,6 +33,14 @@ public class dAdventurer implements dObject, Adjustable {
 		}
 	}
 	
+    public static boolean matches(String string) {
+        return valueOf(string) != null;
+    }
+    
+	public static dAdventurer valueOf(String uuid) {
+		return valueOf(uuid, null);
+	}
+	
 	public Adventurer getAdventurer() {
 		return this.adventurer;
 	}
@@ -104,6 +112,7 @@ public class dAdventurer implements dObject, Adjustable {
 		// TODO Auto-generated method stub
 		
 	}
+	
     @Fetchable("adventurer")
     public static dAdventurer valueOf(String string, TagContext context) {
         if (string == null) {

--- a/src/com/phenom/argonauts/denizens/dPlayerExt.java
+++ b/src/com/phenom/argonauts/denizens/dPlayerExt.java
@@ -4,6 +4,7 @@ import com.phenom.argonauts.Main;
 
 import net.aufdemrand.denizen.objects.dPlayer;
 import net.aufdemrand.denizencore.objects.Element;
+import net.aufdemrand.denizencore.objects.Mechanism;
 import net.aufdemrand.denizencore.objects.dObject;
 import net.aufdemrand.denizencore.tags.Attribute;
 
@@ -29,6 +30,16 @@ public class dPlayerExt extends dObjectExtension {
     	if (a.startsWith("isadventurer")) {
     		return new Element(Main.adventurers.containsKey(dplayer.getName())).getAttribute(a.fulfill(1));
     	}
+    	//Here is my attempt of how I think I'd go about returning a dAdventurer
+    	else if (a.startsWith("adventurer")) { 	
+    		return new dAdventurer(Main.adventurers.get(this.dplayer.getName())).getAttribute(a.fulfill(1));
+    	}
+    	//End Nave's Attempt
     	return new Element(this.dplayer.identify()).getAttribute(a);
     }
+	
+	@Override
+	public void adjust(Mechanism m) {
+	}
+    
 }


### PR DESCRIPTION
```
test:
  type: world
  events:

    on player right clicks block:
		- if <player.isadventurer> == true {
			- announce <player.adventurer>
			- announce <player.adventurer.abilitypoints>
			- announce <player.adventurer.atk>
			- adjust <player.adventurer> atk:2.0
		}
```

If you want to check our code try this denizen event. At first it check if the right clicking player is a adventurer and if true broadcast the dadventurer along with abilitypoints and atk. Right after set atk to 2.0.  Next time we right click a block atk is at 2.0.

You sure already noticed. We need the dplayerext class to add isadventurer and adventurer tag to dplayer. If we add this tags to dplayer we are able to check if player is an adventurer and we can get the adventurer instance. Once we have the adventurer instance from player.adventurer we continue in the dadventurer class and get the tags and mechs from there.

Thats the way to create new dobjects and add tags and mechs to them or extend an existing dobject with tags / mechs.